### PR TITLE
feat: `two-cols` layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,35 @@ The default layout of the first slide.
 
 The layout for almost all-yellow slides with bold centered title.
 
+#### `layout: two-cols`
+
+A layout with two columns, providing two optional `::left::` and `::right::` slots.
+
+```md
+---
+layout: two-cols
+---
+
+# This takes the full width
+
+::left::
+
+## Left
+
+This shows on the left
+
+::right::
+
+## Right
+
+This shows on the right
+```
+
 #### `layout: thank_you`
 
 The layout to end your presentation.
 
-##### `layout: thank_you` `::speaker::`
-
-This layout provides an optional `speaker` placeholder, located at the bottom right of the slide.
+This layout provides an optional `::speaker::` slot, located at the bottom right of the slide.
 
 You can use the `<SpeakerCard>` component to fill it.
 

--- a/example.md
+++ b/example.md
@@ -52,6 +52,28 @@ layout: title
 # Slide with title layout
 
 ---
+layout: two-cols
+---
+
+# This spans on the top
+
+::left::
+
+# Left
+
+This shows on the left
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+::right::
+
+# Right
+
+This shows on the right
+
+![](https://placehold.co/600x400)
+
+---
 layout: thank_you
 ---
 

--- a/layouts/two-cols.vue
+++ b/layouts/two-cols.vue
@@ -1,0 +1,19 @@
+<script setup>
+import MainLayout from "../components/main-layout.vue";
+</script>
+
+<template>
+  <MainLayout name="two-cols">
+    <slot />
+
+    <div v-if="$slots.left || $slots.right" class="grid grid-cols-2 gap-x-6">
+      <div v-if="$slots.left || $slots.right">
+        <slot name="left" />
+      </div>
+
+      <div v-if="$slots.right">
+        <slot name="right" />
+      </div>
+    </div>
+  </MainLayout>
+</template>


### PR DESCRIPTION
## Markdown

```md
---
layout: two-cols
---

# This spans on the top

::left::

# Left

This shows on the left

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

::right::

# Right

This shows on the right

![](https://placehold.co/600x400)
```

## Result

<img width="1658" height="933" alt="Capture d’écran 2025-09-02 à 11 50 44" src="https://github.com/user-attachments/assets/af5aa259-1b88-42a4-9b7a-345b22355257" />
